### PR TITLE
Atomic HTML Attribute Test

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -349,6 +349,11 @@
       "locals" : {
         "var" : "a"
       }
+    },
+
+    "HTML-style tag with an atomic attribute" : {
+      "haml" : "%a(flag)",
+      "html" : "<a flag></a>"
     }
   },
 


### PR DESCRIPTION
There didn't seem to be any test for atomic attributes... aka

    %div(flag)
    <div flag></div>

So, I added it as a test case! This works in Ruby Haml 4.1, but not sure about the others. It should! :+1: 