### PR TITLE
"MiniTest::Unit::TestCase is now Minitest::Test."

### DIFF
--- a/ruby_haml_test.rb
+++ b/ruby_haml_test.rb
@@ -3,7 +3,7 @@ require "minitest/autorun"
 require "json"
 require "haml"
 
-class HamlTest < MiniTest::Unit::TestCase
+class HamlTest < (defined?(Minitest::Test) ? Minitest::Test : MiniTest::Unit::TestCase)
   contexts = JSON.parse(File.read(File.dirname(__FILE__) + "/tests.json"))
   contexts.each do |context|
     context[1].each do |name, test|


### PR DESCRIPTION
Here's a fix for the Minitest :warning:
