### PR TITLE
Test runner for django-hamlpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ The Lua test depends on
 [Lua Haml](http://github.com/norman/lua-haml). Install and run `tsc
 lua_haml_spec.lua`.
 
+### Python/Django ###
+
+The Python tests use [django-hamlpy](https://github.com/nyaruka/django-hamlpy)
+implementation. To install and the run the tests:
+
+    pip install django-hamlpy
+    python python_haml_test.py
+
 ### Getting it ###
 
 You can access the [Git repository](http://github.com/norman/haml-spec) at:

--- a/python_haml_test.py
+++ b/python_haml_test.py
@@ -1,0 +1,37 @@
+from __future__ import print_function, unicode_literals
+
+import json
+
+from collections import OrderedDict
+from hamlpy import compiler
+
+
+def run_test(test, description):
+    try:
+        html = compiler.Compiler(options=test.get('config')).process(test['haml'])
+        error = None
+    except Exception as e:
+        html = ''
+        error = e
+
+    if html.strip() == test['html']:
+        print(" > %s OK" % description)
+    elif error:
+        print(" > %s: ERROR" % description)
+        print("   Exception: %s" % str(error))
+    else:
+        print(" > %s: FAIL" % description)
+        print("   Expected: %s" % test['html'].replace('\n', '\\n'))
+        print("   Actual  : %s" % html.replace('\n', '\\n'))
+
+
+def run_all():
+    with open('tests.json') as f:
+        tests = json.load(f, object_pairs_hook=OrderedDict)
+        for category, category_tests in tests.items():
+            print(category)
+            for description, test in category_tests.items():
+                run_test(test, description)
+
+
+run_all()

--- a/python_haml_test.py
+++ b/python_haml_test.py
@@ -6,32 +6,26 @@ from collections import OrderedDict
 from hamlpy import compiler
 
 
-def run_test(test, description):
-    try:
-        html = compiler.Compiler(options=test.get('config')).process(test['haml'])
-        error = None
-    except Exception as e:
-        html = ''
-        error = e
+num_pass, num_fail, num_error = 0, 0, 0
 
-    if html.strip() == test['html']:
-        print(" > %s OK" % description)
-    elif error:
-        print(" > %s: ERROR" % description)
-        print("   Exception: %s" % str(error))
-    else:
-        print(" > %s: FAIL" % description)
-        print("   Expected: %s" % test['html'].replace('\n', '\\n'))
-        print("   Actual  : %s" % html.replace('\n', '\\n'))
+with open('tests.json') as f:
+    tests = json.load(f, object_pairs_hook=OrderedDict)
+    for category, category_tests in tests.items():
+        print(category)
+        for description, test in category_tests.items():
+            try:
+                html = compiler.Compiler(options=test.get('config')).process(test['haml']).strip()
+                if html == test['html']:
+                    print(" > %s: OK" % description)
+                    num_pass += 1
+                else:
+                    print(" > %s: FAIL" % description)
+                    print("    - Expected: %s" % test['html'].replace('\n', '\\n'))
+                    print("    - Actual  : %s" % html.replace('\n', '\\n'))
+                    num_fail += 1
+            except Exception as e:
+                print(" > %s: ERROR" % description)
+                print("    - Exception: %s" % str(e))
+                num_error += 1
 
-
-def run_all():
-    with open('tests.json') as f:
-        tests = json.load(f, object_pairs_hook=OrderedDict)
-        for category, category_tests in tests.items():
-            print(category)
-            for description, test in category_tests.items():
-                run_test(test, description)
-
-
-run_all()
+print("==== Passed: %d, Failed: %d, Errors: %d ====" % (num_pass, num_fail, num_error))


### PR DESCRIPTION
Still a lot of test failures, mainly due to:

- No concept yet of 'ugly' formatting which is now the default for the Ruby implementation. We plan to add this.
- No real variable substitution as [django-hamlpy](https://github.com/nyaruka/django-hamlpy) isn't a template engine so much as a pre-processor - i.e. `#{foo}` becomes `{{foo}}` and we let the regular Django template engine do substitution of `foo`.

But figured it was worth making a PR at this point so people are aware of us as a Haml implementation. The runner prints a bit more information than the other ones but that's because I'm currently using it to track down issues.